### PR TITLE
Improve the accuracy of FPS limiter and audio quality

### DIFF
--- a/app/src/main/java/cn/navclub/nes4j/app/view/GameWorld.java
+++ b/app/src/main/java/cn/navclub/nes4j/app/view/GameWorld.java
@@ -4,7 +4,6 @@ import cn.navclub.nes4j.app.assets.FXResource;
 import cn.navclub.nes4j.app.INes;
 import cn.navclub.nes4j.app.audio.JavaXAudio;
 import cn.navclub.nes4j.app.config.NESConfig;
-import cn.navclub.nes4j.app.control.IconPopup;
 import cn.navclub.nes4j.app.service.TaskService;
 import cn.navclub.nes4j.app.dialog.DHandle;
 import cn.navclub.nes4j.app.event.GameEventWrap;
@@ -12,6 +11,7 @@ import cn.navclub.nes4j.app.model.KeyMapper;
 import cn.navclub.nes4j.app.util.StrUtil;
 import cn.navclub.nes4j.app.util.UIUtil;
 import cn.navclub.nes4j.bin.NesConsole;
+import cn.navclub.nes4j.bin.config.AudioSampleRate;
 import cn.navclub.nes4j.bin.io.JoyPad;
 import cn.navclub.nes4j.bin.logging.LoggerDelegate;
 import cn.navclub.nes4j.bin.logging.LoggerFactory;
@@ -125,6 +125,7 @@ public class GameWorld extends Stage {
                         .newBuilder()
                         .file(file)
                         .player(JavaXAudio.class)
+                        .sampleRate(AudioSampleRate.HZ44100)
                         .gameLoopCallback(GameWorld.this::gameLoopCallback)
                         .build();
                 GameWorld.this.console.execute();

--- a/bin/src/main/java/cn/navclub/nes4j/bin/apu/impl/TriangleChannel.java
+++ b/bin/src/main/java/cn/navclub/nes4j/bin/apu/impl/TriangleChannel.java
@@ -70,11 +70,7 @@ public class TriangleChannel extends Channel<TriangleSequencer> {
      */
     @Override
     public int output() {
-        if (!this.enable
-                || this.linearCounter.getCounter() == 0
-                || this.lengthCounter.silence()) {
-            return 0;
-        }
+    // Silencing the triangle channel merely halts it. It will continue to output its last value rather than 0.
         return sequencer.value();
     }
 

--- a/bin/src/main/java/cn/navclub/nes4j/bin/apu/impl/timer/TriangleTimer.java
+++ b/bin/src/main/java/cn/navclub/nes4j/bin/apu/impl/timer/TriangleTimer.java
@@ -32,7 +32,7 @@ public class TriangleTimer extends Timer<TriangleSequencer> {
             if (this.counter == 0) {
                 var linearCounter = this.channel.getLinearCounter();
                 var lengthCounter = this.channel.getLengthCounter();
-                if (lengthCounter.getCounter() != 0 && linearCounter.getCounter() != 0) {
+                if (channel.isEnable() && lengthCounter.getCounter() != 0 && linearCounter.getCounter() != 0) {
                     this.sequencer.tick();
                 }
             }

--- a/bin/src/main/java/cn/navclub/nes4j/bin/ppu/PPU.java
+++ b/bin/src/main/java/cn/navclub/nes4j/bin/ppu/PPU.java
@@ -556,7 +556,8 @@ public class PPU implements Component {
         var unit = 1000000000 / this.console.TVFps();
         var span = unit - (now - this.lastFrameTime);
         if (span > 0) {
-            LockSupport.parkNanos(span);
+            LockSupport.parkNanos(span - 2000);
+            while(System.nanoTime() < now + span);
             this.lastFrameTime = System.nanoTime();
         } else {
             this.lastFrameTime = now + span;


### PR DESCRIPTION
- Improve the accuracy of FPS limiter
- Mute triangle channle should't output zero
- Use 44.1KHz sample rate by default for  compatibility
